### PR TITLE
Feature/multiple options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ You can find options documented as [HeadlessOptions](https://github.com/ArrayKni
 
 ```js
 {
-    graphql?: ApolloBoostClientConfig
-    restful?: AxiosClientConfig
+    graphql?: GraphQLOptionsTypes
+    restful?: RestfulOptionsTypes
     jsonDark?: ReactJsonViewThemeKey
     jsonLight?: ReactJsonViewThemeKey
 }

--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -186,7 +186,7 @@ export const Panel = memo(({ active }: Props) => {
                     <Message collapisble={isGraphQLParameters(params)}>
                         {isGraphQLParameters(params)
                             ? getGraphQLUri(graphql, params)
-                            : getRestfulUrl(restful, params, {}, true)}
+                            : getRestfulUrl(restful, params, {})}
                     </Message>
                     <Variables
                         hasData={hasData}

--- a/src/examples/options.stories.mdx
+++ b/src/examples/options.stories.mdx
@@ -18,9 +18,13 @@ By utilizing options when setting up the Headless decorator, its possible to est
 
 A partial [Axios config](https://github.com/axios/axios#request-config) can be passed in as a base config. The most common use case would be to establish a `baseURL` so that all stories can have a simpler relative query.
 
+Or an array of partial Axios configs with ids. Each config's id should be unique and is used to look up the base config referenced by the `base` property in the story parameters.
+
 ## GraphQL
 
 A partial [Apollo Boost config](https://www.apollographql.com/docs/react/get-started/#configuration-options) can be passed in as a base config. The most common use case would be to establish a `uri` so that all stories can simply define a query without the need for an additional config.
+
+Or an array of partial Apollo Boost configs with ids. Each config's id should be unique and is used to look up the base config referenced by the `base` property in the story parameters.
 
 ## Theming
 

--- a/src/examples/parameters.stories.mdx
+++ b/src/examples/parameters.stories.mdx
@@ -34,9 +34,13 @@ import { pack } from 'storybook-addon-headless'
 }
 ```
 
+## Base
+
+If multiple base configs have been provided via options, use this property to select which base config to merge with.
+
 ## Config
 
-If a specific query needs to augment the base config, you can optionally pass a partial config to be merged with the config that may have been supplied in the options. See options about what configs are accepted.
+If a specific query needs to augment the base config, you can optionally pass a partial config to be merged with the base config that may have been supplied in the options. See options about what configs are accepted.
 
 ## Query [required]
 

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -2,16 +2,20 @@ export interface Dictionary<T = any> {
     [key: string]: T
 }
 
+export type Identifiable<T extends {}> = T & { id: string }
+
 export interface Item {
     label: string
     value: any
 }
 
-export type Transform<T = any> = (value: T) => T
+export type OneOrMore<T extends {}> = T | Identifiable<T>[]
 
 export type Required<T> = T extends object
     ? { [P in keyof T]-?: NonNullable<T[P]> }
     : T
+
+export type Transform<T = any> = (value: T) => T
 
 export enum FetchStatus {
     Inactive,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2,13 +2,17 @@ import { AxiosRequestConfig as AxiosClientConfig } from 'axios'
 import { PresetConfig as ApolloClientConfig } from 'apollo-boost'
 import { ThemeKeys } from 'react-json-view'
 
+import { OneOrMore } from './generic'
+
 export type RestfulOptions = AxiosClientConfig
+export type RestfulOptionsTypes = OneOrMore<RestfulOptions>
 
 export type GraphQLOptions = ApolloClientConfig
+export type GraphQLOptionsTypes = OneOrMore<GraphQLOptions>
 
 export interface HeadlessOptions {
-    restful?: RestfulOptions
-    graphql?: GraphQLOptions
+    restful?: RestfulOptionsTypes
+    graphql?: GraphQLOptionsTypes
     jsonDark?: ThemeKeys
     jsonLight?: ThemeKeys
 }

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -19,6 +19,7 @@ export interface VariableParameters {
 }
 
 export interface BaseParameters {
+    base?: string
     variables?: VariableParameters
     defaults?: Dictionary
     transforms?: Dictionary<Transform>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,7 +1,8 @@
 import { ValidateFunction } from 'ajv'
 
-import { Dictionary, Required, Schema, VariableType } from './generic'
+import { Dictionary, Required, VariableType } from './generic'
 import { HeadlessOptions } from './options'
+import { Schema } from './schemas'
 
 export interface HeadlessState {
     storyId: string


### PR DESCRIPTION
## Description

Add new feature to allow for multiple base configs. These base configs get referenced by the parameters via the `base` property. This gives the ability to hit multiple APIs of the same type from a single storybook config without needing to setup everything via parameters.

## Documentation

Readme, options & parameters documentation all reflect changes
